### PR TITLE
feat: entries status

### DIFF
--- a/.changeset/lazy-pets-breathe.md
+++ b/.changeset/lazy-pets-breathe.md
@@ -1,0 +1,5 @@
+---
+"@goulvenclech/astropi": minor
+---
+
+Entries now have a `status` field in their frontmatter, `published` by default. If set to `draft`, the entry will not be displayed in the UI. In development mode, you will still be able to access your draft through the URL.

--- a/docs/src/content/blog/2024/diary-april-astro-build/index.md
+++ b/docs/src/content/blog/2024/diary-april-astro-build/index.md
@@ -2,6 +2,7 @@
 title: "Dev Diary: How Astro generates your site?"
 date: 2024-04-30
 abstract: "Astro is a fast and modern Static Site Generator. This article explains how Astro works, how it stands out from the competition, and why it's the perfect choice for beginners."
+status: "draft"
 ---
 
 Blabla

--- a/docs/src/content/learn/3-create-a-blog.md
+++ b/docs/src/content/learn/3-create-a-blog.md
@@ -39,3 +39,5 @@ Welcome to my blog, this is my first post!
 
 Run `npm run dev` and go to `http://localhost:4321/blog/my-first-blog-post` to see your blog post.
 
+If you want to hide your blog post in production, add a `status: "draft"` field in the frontmatter. In development mode, you will still be able to access your draft through the URL, but it won't be displayed in the UI.
+

--- a/packages/astropi/utils/collections-entries.ts
+++ b/packages/astropi/utils/collections-entries.ts
@@ -31,7 +31,7 @@ export async function getCollectionTypeEntries(type: string) {
 }
 
 /**
- * For a given collection, get all the collection entries
+ * For a given collection, get all the published collection entries.
  * @param collection - The collection to get the entries from
  */
 export async function getCollectionEntries(collection: string) {
@@ -44,9 +44,11 @@ export async function getCollectionEntries(collection: string) {
       return collection
     })
   )
-  // Filter the collections for a given collection
+  // Filter the published entries for a given collection
   const allBlogContentEntries = allAstropiCollectionsEntries
     .flat()
     .filter((entry) => entry.collection === collection)
+    .filter((entry) => entry.data.status === "published")
+
   return allBlogContentEntries
 }

--- a/packages/astropi/utils/collections-entries.ts
+++ b/packages/astropi/utils/collections-entries.ts
@@ -7,6 +7,7 @@ import { userConfig } from "virtual:astropi-user-config"
 
 /**
  * For a given collection type, get all the collection entries.
+ * In production, only published entries are returned.
  * @param type - An Astropi collection type, see "collections-schemas.ts"
  */
 export async function getCollectionTypeEntries(type: string) {
@@ -23,6 +24,13 @@ export async function getCollectionTypeEntries(type: string) {
   const allBlogContentEntries = allAstropiCollectionsEntries
     .flat()
     .filter((entry) => entry.data.type === type)
+    // In production, only return published entries
+    .filter((entry) => {
+      if (import.meta.env.PROD) {
+        return entry.data.status === "published"
+      }
+      return true
+    })
   // Finnaly, return the params and props for each entry
   return allBlogContentEntries.map((entry) => ({
     params: { slug: entry.slug },

--- a/packages/astropi/utils/collections-schemas.ts
+++ b/packages/astropi/utils/collections-schemas.ts
@@ -26,6 +26,7 @@ export const docsContentCollection = {
   schema: z.object({
     type: z.literal("docs-content").default("docs-content"),
     title: z.string(),
+    status: z.enum(["published", "draft"]).default("published"),
   }),
 }
 
@@ -37,5 +38,6 @@ export const docsOpenApiCollection = {
   schema: z.object({
     type: z.literal("docs-openapi").default("docs-openapi"),
     title: z.string(),
+    status: z.enum(["published", "draft"]).default("published"),
   }),
 }

--- a/packages/astropi/utils/collections-schemas.ts
+++ b/packages/astropi/utils/collections-schemas.ts
@@ -14,6 +14,7 @@ export const blogContentCollection = {
     title: z.string(),
     abstract: z.string(),
     date: z.date(),
+    status: z.enum(["published", "draft"]).default("published"),
   }),
 }
 


### PR DESCRIPTION
## What does this change?

- Added a enum `status` in `blog` zod schema, can be "draft" or "published" (published by default).
- Use this status to hide draft blog entries in blogs.
- Use this status to not build draft blog entries in production.

## How is it documented?

Added a line about it in `docs/src/content/learn/3-create-a-blog.md`.